### PR TITLE
WIP: Add NewTrack to PeerConnection

### DIFF
--- a/webrtc/peerconnection.go
+++ b/webrtc/peerconnection.go
@@ -12,7 +12,7 @@ type PeerConnection interface {
 	// Returned RTPTransceiver will be a bidirectional stream by default.
 	//
 	// ref: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver
-	AddTransceiverFromTrack(LocalTrack, *RTPTransceiverInit) (RTPTransceiver, error)
+	AddTransceiverFromTrack(LocalRTPTrack, *RTPTransceiverInit) (RTPTransceiver, error)
 	// AddTransceiverFromTrack creates a new RTPTransceiver from RTPCodecType
 	// and register it to the PeerConnection.
 	// Pass nil as a second argument to use default setting.
@@ -20,6 +20,9 @@ type PeerConnection interface {
 	//
 	// ref: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver
 	AddTransceiverFromKind(webrtc.RTPCodecType, *RTPTransceiverInit) (RTPTransceiver, error)
+
+	// NewTrack creates a new LocalRTPTrack.
+	NewTrack(c webrtc.RTPCodecCapability, ssrc uint32, id, label string) (LocalRTPTrack, error)
 }
 
 // RTPTransceiverInit represents RTCRtpTransceiverInit dictionary.


### PR DESCRIPTION
#### Description
Adds a `PeerConnection::NewTrack` for creating a `LocalRTPTrack` using a `webrtc.CodecCapability` instead of `PayloadType`. IMHO the `MediaEngine` settings could be used to check if it's an audio or video track.

#### Reference issue
Fixes #8.