### PR TITLE
Add mediadevices use case example

### DIFF
--- a/examples/portable-getusermedia/README.md
+++ b/examples/portable-getusermedia/README.md
@@ -1,0 +1,3 @@
+# portable-getusermedia
+
+This is only an imaginary example. Some of the APIs don't exist yet, but the example should show the overall flow how things will work together.

--- a/examples/portable-getusermedia/main.go
+++ b/examples/portable-getusermedia/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"github.com/pion/mediadevices"
+	"github.com/pion/mediadevices/pkg/codec/openh264"
+	"github.com/pion/mediadevices/pkg/codec/x264"
+	"github.com/pion/mediadevices/pkg/prop"
+
+	// Note: If you don't have a camera or microphone or your adapters are not supported,
+	//       you can always swap your adapters with our dummy adapters below.
+	// _ "github.com/pion/mediadevices/pkg/driver/videotest"
+	_ "github.com/pion/mediadevices/pkg/driver/camera" // This is required to register camera adapter
+)
+
+func main() {
+	var setting webrtc.SettingEngine
+
+	x264Params, _ := x264.NewParams()
+	openh264Params, _ := openh264.NewParams()
+	rtpTracker, _ := mediadevices.NewRTPTracker(x264Params, openh264Params)
+	rtpTracker.PopulateSetting(&setting)
+
+	// User can still modify setting to their needs here
+
+	api := webrtc.NewAPI(webrtc.WithSettingEngine(&setting))
+
+	// Assume that we have configured the api and have proper config
+	pc, _ := api.NewPeerConnection(peerConnectionConfig)
+
+	mediaStream, _ := mediadevices.GetUserMedia(mediadevices.MediaStreamConstraints{
+		Video: func(constraint *mediadevices.MediaTrackConstraints) {
+			constraint.Width = prop.Int(600)
+			constraint.Height = prop.Int(400)
+		},
+	})
+
+	for _, mediaTrack := range mediaStream.GetTracks() {
+		// rtpTracker.Track will create LocalRTPTrack, which later can be used for pulling video/audio frames.
+		pc.AddTransceiverFromTrack(rtpTracker.Track(mediaTrack),
+			webrtc.RtpTransceiverInit{
+				Direction: webrtc.RTPTransceiverDirectionSendonly,
+			},
+		)
+	}
+
+	// peerconnection should negotiate with the other peer
+	// peerconnection should set the negotiated codec with LocalRTPTrack.setParameters()
+
+	// mediadevices then will set the codec and attach the encoder to the pipeline. PeerConnection now can start
+	// pulling encoded frames from mediadevices.
+	//
+	// Question: How are we going to handle errors from the encoder, e.g. invalid resolutions, invalid sample rate, etc.?
+	//           Should we return the error when the user calls SetRemoteDescription?
+}


### PR DESCRIPTION
The example that I created here is just imaginary. But, I think it should be able to still show the overall flow how things work with mediadevices.

I think overall the new APIs look really good! I only have some minor concerns:

1. When to add available codecs? Are we going to still use the media engine? Or should we add a method to LocalRTPTrack, maybe `GetRTPCodecCapabilities` to get the list of available codecs for a particular track? Doing this per track will give us benefit of setting available codecs during runtime, which should be able to address https://github.com/pion/webrtc-v3-design/issues/3 and https://github.com/pion/webrtc-v3-design/issues/8.
2.  How to handle errors that are coming from encoders, specifically when PeerConnection calls `LocalRTPTrack.setParameters()`? Should we propagate this error to the user through `SetRemoteDescription`?