### PR TITLE
Add Stop to TrackBase

### DIFF
--- a/webrtc/track.go
+++ b/webrtc/track.go
@@ -7,6 +7,7 @@ import (
 // TrackBase represents common MediaStreamTrack functionality of LocalTrack and RemoteTrack.
 type TrackBase interface {
 	ID() string
+	Stop() error
 }
 
 // LocalRTPTrack represents MediaStreamTrack which is fed by the local stream source.


### PR DESCRIPTION
As specified in https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-close, when PeerConnection gets closed, it needs to also close all owned transceivers, which eventually propagate to Tracks. 

It's important for tracks to be notified for any close/stop events so that the implementation can properly clean up resources, e.g. closing drivers, stopping Gstreamer pipeline, terminating RTSP server, etc.