### PR TITLE
Add interfaces to connect Local/RemoteTrack and RTPSender/Receiver

### DIFF
--- a/rtpengine/interceptor.go
+++ b/rtpengine/interceptor.go
@@ -1,14 +1,18 @@
 package rtpengine
 
+import (
+	"context"
+)
+
 // WriteInterceptor processes outbound RTP stream.
 // For example, WriteInterceptor may implements congestion control and packet retransmission.
 type WriteInterceptor interface {
-	Intercept(Writer) Writer
+	Intercept(context.Context, Writer) Writer
 }
 
 // ReadInterceptor processes received RTP stream.
 // For example, ReadInterceptor may implements RTP jitter buffer, RTCP report sender,
 // and packet retransmission request.
 type ReadInterceptor interface {
-	Intercept(Reader) Reader
+	Intercept(context.Context, Reader) Reader
 }

--- a/rtpengine/io.go
+++ b/rtpengine/io.go
@@ -16,3 +16,8 @@ type Writer interface {
 	WriteRTP(*rtp.Packet) error
 	ReadRTCP() (rtcp.Packet, error)
 }
+
+// Copy rtp.Packet from Reader to Writer and rtcp.Packet from Writer to Reader.
+func Copy(Writer, Reader) error {
+	panic("unimplemented")
+}

--- a/rtpengine/io.go
+++ b/rtpengine/io.go
@@ -1,23 +1,25 @@
 package rtpengine
 
 import (
+	"context"
+
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 )
 
 // Reader is an interface to handle incoming RTP stream.
 type Reader interface {
-	ReadRTP() (*rtp.Packet, error)
-	WriteRTCP(rtcp.Packet) error
+	ReadRTP(context.Context) (*rtp.Packet, error)
+	WriteRTCP(context.Context, rtcp.Packet) error
 }
 
 // Writer is an interface to handle outgoing RTP stream.
 type Writer interface {
-	WriteRTP(*rtp.Packet) error
-	ReadRTCP() (rtcp.Packet, error)
+	WriteRTP(context.Context, *rtp.Packet) error
+	ReadRTCP(context.Context) (rtcp.Packet, error)
 }
 
 // Copy rtp.Packet from Reader to Writer and rtcp.Packet from Writer to Reader.
-func Copy(Writer, Reader) error {
+func Copy(context.Context, Writer, Reader) error {
 	panic("unimplemented")
 }

--- a/rtpengine/jitterbuffer/jitterbuffer.go
+++ b/rtpengine/jitterbuffer/jitterbuffer.go
@@ -1,6 +1,8 @@
 package jitterbuffer
 
 import (
+	"context"
+
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 	"github.com/pion/webrtc-v3-design/rtpengine"
@@ -12,7 +14,7 @@ type JitterBuffer struct {
 }
 
 // Intercept implements ReadInterceptor.
-func (j *JitterBuffer) Intercept(r rtpengine.Reader) rtpengine.Reader {
+func (j *JitterBuffer) Intercept(ctx context.Context, r rtpengine.Reader) rtpengine.Reader {
 	return &jitterBufferReader{r}
 }
 
@@ -20,13 +22,13 @@ type jitterBufferReader struct {
 	in rtpengine.Reader
 }
 
-func (j *jitterBufferReader) WriteRTCP(p rtcp.Packet) error {
+func (j *jitterBufferReader) WriteRTCP(ctx context.Context, p rtcp.Packet) error {
 	// This interceptor doesn't use RTCP packet.
-	return j.in.WriteRTCP(p)
+	return j.in.WriteRTCP(ctx, p)
 }
 
-func (j *jitterBufferReader) ReadRTP() (*rtp.Packet, error) {
-	p, err := j.in.ReadRTP()
+func (j *jitterBufferReader) ReadRTP(ctx context.Context) (*rtp.Packet, error) {
+	p, err := j.in.ReadRTP(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/webrtc/peerconnection.go
+++ b/webrtc/peerconnection.go
@@ -8,6 +8,14 @@ type SettingEngine interface {
 	// implements packetization for.
 	SetEncodings([]*RTPCodecCapability) error
 
+	// SetLocalTrackAdapters registers LocalTrackAdapters.
+	// LocalRTPTrack-PassthroughRTPSender is registered by default.
+	SetLocalTrackAdapters([]LocalTrackAdapter) error
+
+	// SetRemoteTrackAdapters registers RemoteTrackAdapters.
+	// RemoteRTPTrack-PassthroughRTPReceiver is registered by default.
+	SetRemoteTrackAdapters([]RemoteTrackAdapter) error
+
 	// NewPeerConnection creates a NewPeerConnection
 	NewPeerConnection(Configuration) (PeerConnection, error)
 }

--- a/webrtc/peerconnection.go
+++ b/webrtc/peerconnection.go
@@ -20,7 +20,7 @@ type PeerConnection interface {
 	// Returned RTPTransceiver will be a bidirectional stream by default.
 	//
 	// ref: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver
-	AddTransceiverFromTrack(LocalRTPTrack, *RTPTransceiverInit) (RTPTransceiver, error)
+	AddTransceiverFromTrack(LocalTrack, *RTPTransceiverInit) (RTPTransceiver, error)
 
 	// AddTransceiverFromKind creates a new RTPTransceiver from RTPCodecType
 	// and register it to the PeerConnection.
@@ -33,7 +33,7 @@ type PeerConnection interface {
 	// OnTrack handles an incoming media feed.
 	//
 	// ref: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/ontrack
-	OnTrack(func(RemoteRTPTrack, RTPReceiver))
+	OnTrack(func(RemoteTrack, RTPReceiver))
 }
 
 // RTPTransceiverInit represents RTCRtpTransceiverInit dictionary.

--- a/webrtc/track.go
+++ b/webrtc/track.go
@@ -1,6 +1,8 @@
 package webrtc
 
 import (
+	"context"
+
 	"github.com/pion/webrtc-v3-design/rtpengine"
 )
 
@@ -22,7 +24,7 @@ type LocalTrackAdapter interface {
 	// PeerConnection.AddTransceiverFromTrack().
 	//
 	// For example of LocalRTPTrack and PassthroughRTPSender, it might be like:
-	//   func Bind(track LocalTrack, sender RTPSender) error {
+	//   func Bind(ctx context.Context, track LocalTrack, sender RTPSender) error {
 	//     rtpTrack, ok := track.(LocalRTPTrack)
 	//     if !ok {
 	//       return ErrIncompatible
@@ -33,9 +35,9 @@ type LocalTrackAdapter interface {
 	//     }
 	//     // RTP packets written via LocalRTPTrack.WriteRTP() will be
 	//     // read by LocalRTPTrack.pipeReader.ReadRTP().
-	//     return rtpengine.Copy(ptSender, rtpTrack.pipeReader)
+	//     return rtpengine.Copy(ctx, ptSender, rtpTrack.pipeReader)
 	//   }
-	Bind(LocalTrack, RTPSender) error
+	Bind(context.Context, LocalTrack, RTPSender) error
 }
 
 // LocalRTPTrack represents MediaStreamTrack which is fed by the local stream source.
@@ -66,7 +68,7 @@ type RemoteTrackAdapter interface {
 	// PeerConnection.AddTransceiverFromKind().
 	//
 	// For example of RemoteRTPTrack and PassthroughRTPReceiver, it might be like:
-	//   func Bind(track RemoteTrack, sender RTPReceiver) error {
+	//   func Bind(ctx context.Context, track RemoteTrack, sender RTPReceiver) error {
 	//     rtpTrack, ok := track.(RemoteRTPTrack)
 	//     if !ok {
 	//       return ErrIncompatible
@@ -77,9 +79,9 @@ type RemoteTrackAdapter interface {
 	//     }
 	//     // RTP packets written to RemoteRTPTrack.pipeWriter.WriteRTP() will be read from
 	//     // RemoteRTPTrack.ReadRTP().
-	//     return rtpengine.Copy(rtpTrack.pipeWriter, ptReceiver)
+	//     return rtpengine.Copy(ctx, rtpTrack.pipeWriter, ptReceiver)
 	//   }
-	Bind(RemoteTrack, RTPReceiver) error
+	Bind(context.Context, RemoteTrack, RTPReceiver) error
 }
 
 // RemoteRTPTrack represents MediaStreamTrack which is fed by the remote peer.


### PR DESCRIPTION
### Description
Add abstract interfaces LocalTrack, RemoteTrack and adapter to connect Track and RTPSender/Receiver.
Add some example pseudo code to connect LocalRTPTrack and PassthroughRTPSender.

### Reference issue
https://github.com/pion/webrtc-v3-design/issues/23#issue-694723158