### PR TITLE
Rename mutations of Track and RTPSender/Receiver

### DIFF
--- a/webrtc/peerconnection.go
+++ b/webrtc/peerconnection.go
@@ -9,11 +9,11 @@ type SettingEngine interface {
 	SetEncodings([]*RTPCodecCapability) error
 
 	// SetTrackLocalAdapters registers TrackLocalAdapters.
-	// LocalRTPTrack-PassthroughRTPSender is registered by default.
+	// TrackLocalRTP-RTPSenderPassthrough is registered by default.
 	SetTrackLocalAdapters([]TrackLocalAdapter) error
 
 	// SetTrackRemoteAdapters registers TrackRemoteAdapters.
-	// RemoteRTPTrack-PassthroughRTPReceiver is registered by default.
+	// TrackRemoteRTP-RTPReceiverPassthrough is registered by default.
 	SetTrackRemoteAdapters([]TrackRemoteAdapter) error
 
 	// NewPeerConnection creates a NewPeerConnection

--- a/webrtc/track.go
+++ b/webrtc/track.go
@@ -23,26 +23,26 @@ type TrackLocalAdapter interface {
 	// This will be called internally by RTPSender.ReplaceTrack() and
 	// PeerConnection.AddTransceiverFromTrack().
 	//
-	// For example of LocalRTPTrack and PassthroughRTPSender, it might be like:
+	// For example of TrackLocalRTP and RTPSenderPassthrough, it might be like:
 	//   func Bind(ctx context.Context, track TrackLocal, sender RTPSender) error {
-	//     rtpTrack, ok := track.(LocalRTPTrack)
+	//     rtpTrack, ok := track.(TrackLocalRTP)
 	//     if !ok {
 	//       return ErrIncompatible
 	//     }
-	//     ptSender, ok := sender.(PassthroughRTPSender)
+	//     ptSender, ok := sender.(RTPSenderPassthrough)
 	//     if !ok {
 	//       return ErrIncompatible
 	//     }
-	//     // RTP packets written via LocalRTPTrack.WriteRTP() will be
-	//     // read by LocalRTPTrack.pipeReader.ReadRTP().
+	//     // RTP packets written via TrackLocalRTP.WriteRTP() will be
+	//     // read by TrackLocalRTP.pipeReader.ReadRTP().
 	//     return rtpengine.Copy(ctx, ptSender, rtpTrack.pipeReader)
 	//   }
 	Bind(context.Context, TrackLocal, RTPSender) error
 }
 
-// LocalRTPTrack represents MediaStreamTrack which is fed by the local stream source.
+// TrackLocalRTP represents MediaStreamTrack which is fed by the local stream source.
 // Unlike WebAPI's MediaStreamTrack, the track directly provides RTP stream.
-type LocalRTPTrack interface {
+type TrackLocalRTP interface {
 	TrackLocal
 	rtpengine.Writer
 
@@ -67,26 +67,26 @@ type TrackRemoteAdapter interface {
 	// Bind should implement the way how the media data flows from RTPReceiver to TrackRemote.
 	// PeerConnection.AddTransceiverFromKind().
 	//
-	// For example of RemoteRTPTrack and PassthroughRTPReceiver, it might be like:
+	// For example of TrackRemoteRTP and RTPReceiverPassthrough, it might be like:
 	//   func Bind(ctx context.Context, track TrackRemote, sender RTPReceiver) error {
-	//     rtpTrack, ok := track.(RemoteRTPTrack)
+	//     rtpTrack, ok := track.(TrackRemoteRTP)
 	//     if !ok {
 	//       return ErrIncompatible
 	//     }
-	//     ptReceiver, ok := sender.(PassthroughRTPReceiver)
+	//     ptReceiver, ok := sender.(RTPReceiverPassthrough)
 	//     if !ok {
 	//       return ErrIncompatible
 	//     }
-	//     // RTP packets written to RemoteRTPTrack.pipeWriter.WriteRTP() will be read from
-	//     // RemoteRTPTrack.ReadRTP().
+	//     // RTP packets written to TrackRemoteRTP.pipeWriter.WriteRTP() will be read from
+	//     // TrackRemoteRTP.ReadRTP().
 	//     return rtpengine.Copy(ctx, rtpTrack.pipeWriter, ptReceiver)
 	//   }
 	Bind(context.Context, TrackRemote, RTPReceiver) error
 }
 
-// RemoteRTPTrack represents MediaStreamTrack which is fed by the remote peer.
+// TrackRemoteRTP represents MediaStreamTrack which is fed by the remote peer.
 // Unlike WebAPI's MediaStreamTrack, the track directly consumes RTP stream.
-type RemoteRTPTrack interface {
+type TrackRemoteRTP interface {
 	TrackRemote
 	rtpengine.Reader
 
@@ -130,10 +130,10 @@ type RTPSender interface {
 	SetRTPInterceptor(rtpengine.WriteInterceptor)
 }
 
-// PassthroughRTPSender is a RTPSender which can be used with LocalRTPTrack.
+// RTPSenderPassthrough is a RTPSender which can be used with TrackLocalRTP.
 // RTP packets written through rtpengine.Writer interface will be directly
-// passed to LocalRTPTrack.
-type PassthroughRTPSender interface {
+// passed to TrackLocalRTP.
+type RTPSenderPassthrough interface {
 	RTPSender
 	rtpengine.Writer
 }
@@ -152,9 +152,9 @@ type RTPReceiver interface {
 	SetRTPInterceptor(rtpengine.ReadInterceptor)
 }
 
-// PassthroughRTPReceiver is a RTPReceiver which can be used with RemoteRTPTrack.
+// RTPReceiverPassthrough is a RTPReceiver which can be used with TrackRemoteRTP.
 // Received RTP packets can be directly read through rtpengine.Reader interface.
-type PassthroughRTPReceiver interface {
+type RTPReceiverPassthrough interface {
 	RTPReceiver
 	rtpengine.Reader
 }


### PR DESCRIPTION
- LocalRTPTrack -> TrackLocalRTP
- RemoteRTPTrack -> TrackRemoteRTP
- PassthroughRTPSender -> RTPSenderPassthrough
- PassthroughRTPReceiver -> RTPReceiverPassthrough
